### PR TITLE
chore: Bump version to 0.1.1 (#23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2024-12-18
+
+### Changed
+- Improved CI workflow with path filtering to skip unnecessary tests for docs-only changes
+- Updated PR-based release workflow for better automation
+
+### Fixed
+- PR summary job now correctly handles skipped status from conditional CI jobs
+- Branch protection configuration optimized for solo developer workflow
+
 ## [0.1.0] - 2024-12-18
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-pocket",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Smart Pocket - Personal finance management with OCR receipt scanning",
   "workspaces": [

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smart-pocket/server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Smart Pocket Server - Node.js backend",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v0.1.1

### Summary
Patch release to test the new PR-based release workflow and include recent CI improvements.

### Changes in this Release
- **CI Optimization** (#23): Path filtering to skip tests for docs-only changes
- **PR Summary Fix** (#23): Handle skipped status correctly in summary job
- **Branch Protection**: Optimized for solo developer workflow

### Testing
This PR tests the new automated release workflow:
1. ✅ Version bumped in package.json files
2. ✅ CHANGELOG.md updated
3. ⏳ After merge, GitHub Actions should:
   - Detect version change
   - Create tag v0.1.1
   - Build Docker images
   - Push with tags: :latest, :prod, :v0.1.1, :0.1.1
   - Create GitHub Release

### Files Changed
- `package.json`: 0.1.0 → 0.1.1
- `packages/server/package.json`: 0.1.0 → 0.1.1
- `CHANGELOG.md`: Added v0.1.1 section