### PR TITLE
fix: Add checkout step to QA workflows before git commands

### DIFF
--- a/.github/workflows/deploy-mobile-qa.yml
+++ b/.github/workflows/deploy-mobile-qa.yml
@@ -25,6 +25,11 @@ jobs:
       pr_number: ${{ steps.check.outputs.pr_number }}
     
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Need last 2 commits to get merge commit message
+      
       - name: Extract PR number and check for qa-mobile label
         id: check
         env:

--- a/.github/workflows/deploy-server-qa.yml
+++ b/.github/workflows/deploy-server-qa.yml
@@ -25,6 +25,11 @@ jobs:
       pr_number: ${{ steps.check.outputs.pr_number }}
     
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Need last 2 commits to get merge commit message
+      
       - name: Extract PR number and check for qa-server label
         id: check
         env:


### PR DESCRIPTION
## Problem

QA workflow jobs were failing with 'not a git repository' when trying to extract PR number from commit message.

## Root Cause
Workflows were running git commands without first checking out the repository.

## Solution
Added actions/checkout@v4 step before git commands with fetch-depth: 2 to ensure merge commit is available.

## Files Changed
- .github/workflows/deploy-mobile-qa.yml
- .github/workflows/deploy-server-qa.yml

## Testing
After merge, QA workflows should successfully:
1. Check out repository
2. Extract PR number from merge commit message
3. Fetch PR labels via GitHub API
4. Determine if deployment should proceed