### PR TITLE
fix: #72 QA workflows - Add checkout step before git commands

### DIFF
--- a/.github/workflows/deploy-mobile-qa.yml
+++ b/.github/workflows/deploy-mobile-qa.yml
@@ -25,6 +25,11 @@ jobs:
       pr_number: ${{ steps.check.outputs.pr_number }}
     
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Need last 2 commits to get merge commit message
+      
       - name: Extract PR number and check for qa-mobile label
         id: check
         env:

--- a/.github/workflows/deploy-server-qa.yml
+++ b/.github/workflows/deploy-server-qa.yml
@@ -25,6 +25,11 @@ jobs:
       pr_number: ${{ steps.check.outputs.pr_number }}
     
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Need last 2 commits to get merge commit message
+      
       - name: Extract PR number and check for qa-server label
         id: check
         env:


### PR DESCRIPTION
Closes #72

## Problem
QA workflow jobs fail with 'not a git repository' error when trying to extract PR number from merge commit message.

## Root Cause
Workflows were running git commands without first checking out the repository.

## Solution
Added actions/checkout@v4 step with fetch-depth: 2 before git log command to ensure:
1. Repository is available for git commands
2. Merge commit message is fetched
3. PR number can be extracted from merge commit

## Changes
- .github/workflows/deploy-mobile-qa.yml: Added checkout step
- .github/workflows/deploy-server-qa.yml: Added checkout step

## Testing
After merge, QA workflows should:
- ✅ Check out repository
- ✅ Extract PR number from merge commit message
- ✅ Fetch PR labels via GitHub API
- ✅ Determine if deployment should proceed