### PR TITLE
chore: #80 Mobile - Bump build to 5

### DIFF
--- a/.github/workflows/deploy-mobile-qa.yml
+++ b/.github/workflows/deploy-mobile-qa.yml
@@ -100,6 +100,7 @@ jobs:
         working-directory: apps/mobile
         env:
           ANDROID_HOME: ${{ env.ANDROID_HOME }}
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
           pnpx eas-cli build --platform android --profile quality --local --non-interactive --output=./app-quality.apk
           echo "✅ APK built successfully"

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -22,7 +22,7 @@ const path = require('path');
 // App version and build number
 // NOTE: CHANGE THESE TO MATCH root package.json WHEN UPDATING RELEASES
 const VERSION = '0.1.1';
-const BUILD_NUMBER = 4;
+const BUILD_NUMBER = 5;
 
 // Determine which .env file to load based on APP_VARIANT
 const APP_VARIANT = process.env.APP_VARIANT || 'development';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "smart-pocket",
   "version": "0.1.1",
-  "buildNumber": 4,
+  "buildNumber": 5,
   "private": true,
   "description": "Smart Pocket - Personal finance management with OCR receipt scanning",
   "workspaces": [


### PR DESCRIPTION
Closes #80

## Changes Made
- Applied EXPO_TOKEN environment variable to deploy-mobile-qa.yml workflow
- Bumped buildNumber from 4 to 5 in package.json and app.config.js

## Testing
- QA mobile build will trigger on merge via qa-mobile label
- Verifies EAS build with proper Expo authentication
- Validates APK generation and Firebase App Distribution upload

## Risks & Rollback
- Low risk: Only adds missing EXPO_TOKEN to workflow
- Rollback: Revert commit if build fails