### PR TITLE
feat: #84 Mobile - Dashboard/setup UI cleanup

### DIFF
--- a/apps/mobile/app/index.tsx
+++ b/apps/mobile/app/index.tsx
@@ -14,6 +14,7 @@ export default function DashboardScreen() {
   const [recentTransactions] = useState<Transaction[]>([]);
   const [googleSheetsSyncEnabled] = useState(true); // Enable Google Sheets sync
   const [menuVisible, setMenuVisible] = useState(false);
+  const showOcrFeatures = ocrEnabled;
 
   const handleScanReceipt = () => {
     console.log('Scan receipt pressed');
@@ -101,39 +102,32 @@ export default function DashboardScreen() {
           </Card>
         )}
 
-        <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Recent Transactions</Text>
-          {recentTransactions.length === 0 ? (
-            <Card style={styles.emptyCard}>
-              <Text style={styles.emptyText}>No transactions yet</Text>
-              <Text style={styles.emptyHint}>Tap &quot;Scan Receipt&quot; to get started</Text>
-            </Card>
-          ) : (
-            recentTransactions.slice(0, 5).map(txn => (
-              <Card key={txn.id} style={styles.transactionCard}>
-                <View style={styles.transactionRow}>
-                  <View style={styles.transactionInfo}>
-                    <Text style={styles.transactionPayee}>{txn.payeeName}</Text>
-                    <Text style={styles.transactionDate}>{txn.date}</Text>
+        {showOcrFeatures && (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Recent Transactions</Text>
+            {recentTransactions.length > 0 && (
+              recentTransactions.slice(0, 5).map(txn => (
+                <Card key={txn.id} style={styles.transactionCard}>
+                  <View style={styles.transactionRow}>
+                    <View style={styles.transactionInfo}>
+                      <Text style={styles.transactionPayee}>{txn.payeeName}</Text>
+                      <Text style={styles.transactionDate}>{txn.date}</Text>
+                    </View>
+                    <Text style={styles.transactionAmount}>
+                      ${txn.total.amount}
+                    </Text>
                   </View>
-                  <Text style={styles.transactionAmount}>
-                    ${txn.total.amount}
-                  </Text>
-                </View>
-              </Card>
-            ))
-          )}
-        </View>
+                </Card>
+              ))
+            )}
+          </View>
+        )}
 
-        <View style={styles.section}>
-          {ocrEnabled ? (
+        {showOcrFeatures && (
+          <View style={styles.section}>
             <Button title="📸 Scan Receipt" onPress={handleScanReceipt} size="large" />
-          ) : (
-            <Card style={styles.emptyCard}>
-              <Text style={styles.emptyText}>Receipt scanning is temporarily disabled for this release.</Text>
-            </Card>
-          )}
-        </View>
+          </View>
+        )}
 
         {googleSheetsSyncEnabled && (
           <View style={styles.section}>
@@ -141,15 +135,17 @@ export default function DashboardScreen() {
           </View>
         )}
 
-        <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Quick Actions</Text>
-          <Pressable style={styles.quickAction} onPress={handleManualTransaction}>
-            <Text style={styles.quickActionText}>• Manual Transaction</Text>
-          </Pressable>
-          <Pressable style={styles.quickAction}>
-            <Text style={styles.quickActionText}>• View All Transactions</Text>
-          </Pressable>
-        </View>
+        {showOcrFeatures && (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Quick Actions</Text>
+            <Pressable style={styles.quickAction} onPress={handleManualTransaction}>
+              <Text style={styles.quickActionText}>• Manual Transaction</Text>
+            </Pressable>
+            <Pressable style={styles.quickAction}>
+              <Text style={styles.quickActionText}>• View All Transactions</Text>
+            </Pressable>
+          </View>
+        )}
       </ScrollView>
 
       <SideMenu

--- a/apps/mobile/app/setup.tsx
+++ b/apps/mobile/app/setup.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import { View, Text, StyleSheet, ScrollView, KeyboardAvoidingView, Platform } from 'react-native';
 import { Button } from '../components/Button';
 import { router } from 'expo-router';
 import { TextInput } from '../components/TextInput';
@@ -66,54 +66,72 @@ export default function SetupScreen() {
   };
 
   return (
-    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
-      <View style={styles.logoContainer}>
-        <Text style={styles.logo}>💰</Text>
-        <Text style={styles.title}>Smart Pocket</Text>
-        <Text style={styles.subtitle}>Connect to your server</Text>
-      </View>
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.select({ ios: 'padding', android: 'height' })}
+      keyboardVerticalOffset={Platform.select({ ios: 64, android: 0 })}
+    >
+      <ScrollView
+        style={styles.container}
+        contentContainerStyle={styles.content}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View style={styles.logoContainer}>
+          <Text style={styles.logo}>💰</Text>
+          <Text style={styles.title}>Smart Pocket</Text>
+          <Text style={styles.subtitle}>Connect to your server</Text>
+        </View>
 
-      <View style={styles.form}>
-        <TextInput
-          label="Server URL"
-          value={serverUrl}
-          onChangeText={setServerUrl}
-          placeholder="https://smartpocket.example.com"
-          autoCapitalize="none"
-          autoCorrect={false}
-          keyboardType="url"
-          editable={!loading}
-        />
+        <View style={styles.form}>
+          <TextInput
+            label="Server URL"
+            value={serverUrl}
+            onChangeText={setServerUrl}
+            placeholder="https://smartpocket.example.com"
+            autoCapitalize="none"
+            autoCorrect={false}
+            keyboardType="url"
+            editable={!loading}
+            autoComplete="username"
+            textContentType="username"
+            returnKeyType="next"
+          />
 
-        <TextInput
-          label="API Key"
-          value={apiKey}
-          onChangeText={setApiKey}
-          placeholder="Enter your API key"
-          secureTextEntry
-          showToggleVisibility
-          editable={!loading}
-        />
+          <TextInput
+            label="API Key"
+            value={apiKey}
+            onChangeText={setApiKey}
+            placeholder="Enter your API key"
+            secureTextEntry
+            showToggleVisibility
+            editable={!loading}
+            autoCapitalize="none"
+            autoCorrect={false}
+            autoComplete="password"
+            textContentType="password"
+            returnKeyType="go"
+          />
 
-        {error ? <Text style={styles.error}>{error}</Text> : null}
+          {error ? <Text style={styles.error}>{error}</Text> : null}
 
-        <Button
-          title="Connect to Server"
-          onPress={handleConnect}
-          loading={loading}
-          disabled={!serverUrl || !apiKey || loading}
-        />
-      </View>
+          <Button
+            title="Connect to Server"
+            onPress={handleConnect}
+            loading={loading}
+            disabled={!serverUrl || !apiKey || loading}
+          />
+        </View>
 
-      <Text style={styles.helpText}>
-        ℹ️ Get your API key from your server configuration
-      </Text>
-      {(isDevelopment || hasPrefilledValues) && (
-        <Text style={styles.devNote}>
-          {hasPrefilledValues ? '✓ Pre-filled from GitHub Secrets' : '[DEV MODE] Pre-filled from environment config'}
+        <Text style={styles.helpText}>
+          ℹ️ Get your API key from your server configuration
         </Text>
-      )}
-    </ScrollView>
+        {(isDevelopment || hasPrefilledValues) && (
+          <Text style={styles.devNote}>
+            {hasPrefilledValues ? '✓ Pre-filled from GitHub Secrets' : '[DEV MODE] Pre-filled from environment config'}
+          </Text>
+        )}
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 }
 

--- a/apps/mobile/components/TextInput.tsx
+++ b/apps/mobile/components/TextInput.tsx
@@ -55,6 +55,7 @@ const styles = StyleSheet.create({
     paddingVertical: 12,
     paddingHorizontal: 16,
     fontSize: 16,
+    color: '#000',
     backgroundColor: '#fff',
   },
   inputWithButton: {

--- a/packages/features/google-sheets-sync/ui/src/GoogleSheetsSyncScreen.tsx
+++ b/packages/features/google-sheets-sync/ui/src/GoogleSheetsSyncScreen.tsx
@@ -109,13 +109,15 @@ export function GoogleSheetsSyncScreen({
 
   const formatAmount = (amount: string, currency: string): string => {
     const numAmount = parseFloat(amount);
+    const isNegative = numAmount < 0;
+    const absoluteAmount = Math.abs(numAmount);
     const symbol = getCurrencySymbol(currency);
     // Use toLocaleString for thousands separators
-    const formatted = numAmount.toLocaleString('en-US', {
+    const formatted = absoluteAmount.toLocaleString('en-US', {
       minimumFractionDigits: 2,
       maximumFractionDigits: 2,
     });
-    return `${symbol}${formatted}`;
+    return isNegative ? `-${symbol}${formatted}` : `${symbol}${formatted}`;
   };
 
   const renderBalanceChange = (


### PR DESCRIPTION
## Description
Dashboard hides OCR-only UI when disabled and cleans up setup page secure entry/keyboard UX. Also fixes minus sign placement before currency symbol in Google Sheets sync amounts.

Closes #84

## Changes Made
- Hide OCR/transactions/quick actions/recent transactions when OCR disabled; keep connection + Sheets sync
- Add keyboard avoidance and autofill hints to setup inputs; force text color for secure bullets
- Format negative currency as '-<symbol><amount>' in Sheets sync UI

## Testing
- Not run (UI-only change)