### PR TITLE
release: Version 0.2.1 - iOS AltStore upload via local build

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -21,8 +21,8 @@ const path = require('path');
 
 // App version and build number
 // NOTE: CHANGE THESE TO MATCH root package.json WHEN UPDATING RELEASES
-const VERSION = '0.2.0';
-const BUILD_NUMBER = 7;
+const VERSION = '0.2.1';
+const BUILD_NUMBER = 8;
 
 // Determine which .env file to load based on APP_VARIANT
 const APP_VARIANT = process.env.APP_VARIANT || 'development';

--- a/apps/mobile/scripts/build-ios-local.sh
+++ b/apps/mobile/scripts/build-ios-local.sh
@@ -1,0 +1,207 @@
+#!/bin/bash
+# Build iOS IPA locally without EAS Build
+# This creates an unsigned IPA that can be sideloaded via AltStore
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Parse arguments
+VARIANT=${1:-development}
+SCHEME_NAME=""
+BUNDLE_IDENTIFIER=""
+
+case "$VARIANT" in
+  development)
+    SCHEME_NAME="SmartPocketDev"
+    BUNDLE_IDENTIFIER="io.patterueldev.smartpocket.dev"
+    ;;
+  quality)
+    SCHEME_NAME="SmartPocketQA"
+    BUNDLE_IDENTIFIER="io.patterueldev.smartpocket.quality"
+    ;;
+  production)
+    SCHEME_NAME="SmartPocket"
+    BUNDLE_IDENTIFIER="io.patterueldev.smartpocket"
+    ;;
+  *)
+    echo -e "${RED}❌ Invalid variant: $VARIANT${NC}"
+    echo "Usage: $0 [development|quality|production]"
+    exit 1
+    ;;
+esac
+
+echo -e "${BLUE}🚀 Building iOS IPA for variant: $VARIANT${NC}"
+echo -e "${BLUE}   Scheme: $SCHEME_NAME${NC}"
+echo -e "${BLUE}   Bundle ID: $BUNDLE_IDENTIFIER${NC}"
+echo ""
+
+# Change to mobile app directory
+cd "$(dirname "$0")/.."
+MOBILE_DIR=$(pwd)
+
+# Create builds directory
+mkdir -p builds
+
+# Step 1: Clean previous builds
+echo -e "${YELLOW}🧹 Cleaning previous builds...${NC}"
+if [ -d "ios" ]; then
+  rm -rf ios/build
+fi
+
+# Step 2: Prebuild iOS project
+echo -e "${YELLOW}📦 Running expo prebuild for iOS...${NC}"
+APP_VARIANT=$VARIANT pnpx expo prebuild --platform ios --clean
+
+if [ ! -d "ios" ]; then
+  echo -e "${RED}❌ Prebuild failed - ios directory not created${NC}"
+  exit 1
+fi
+
+echo -e "${GREEN}✅ Prebuild complete${NC}"
+echo ""
+
+# Step 3: Install CocoaPods dependencies
+echo -e "${YELLOW}📚 Installing CocoaPods dependencies...${NC}"
+cd ios
+pod install --repo-update
+cd ..
+echo -e "${GREEN}✅ CocoaPods installed${NC}"
+echo ""
+
+# Step 4: Build with xcodebuild
+echo -e "${YELLOW}🔨 Building with xcodebuild...${NC}"
+echo -e "${BLUE}   This may take several minutes...${NC}"
+
+# Determine workspace and scheme
+WORKSPACE="ios/${SCHEME_NAME}.xcworkspace"
+if [ ! -d "$WORKSPACE" ]; then
+  WORKSPACE="ios/SmartPocket.xcworkspace"
+fi
+
+# Export environment variables for Metro bundler (runs during xcodebuild)
+export APP_VARIANT=$VARIANT
+export NODE_ENV=production
+
+# Build for generic iOS device (not simulator)
+xcodebuild \
+  -workspace "$WORKSPACE" \
+  -scheme "$SCHEME_NAME" \
+  -configuration Release \
+  -sdk iphoneos \
+  -destination generic/platform=iOS \
+  -archivePath "ios/build/${SCHEME_NAME}.xcarchive" \
+  archive \
+  CODE_SIGN_IDENTITY="" \
+  CODE_SIGNING_REQUIRED=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  DEVELOPMENT_TEAM=""
+
+if [ $? -ne 0 ]; then
+  echo -e "${RED}❌ xcodebuild failed${NC}"
+  exit 1
+fi
+
+echo -e "${GREEN}✅ Build complete${NC}"
+echo ""
+
+# Step 5: Export IPA from archive
+echo -e "${YELLOW}📱 Exporting IPA...${NC}"
+
+# Create export options plist for ad-hoc/development
+cat > ios/build/ExportOptions.plist << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>development</string>
+    <key>signingStyle</key>
+    <string>manual</string>
+    <key>stripSwiftSymbols</key>
+    <true/>
+    <key>uploadSymbols</key>
+    <false/>
+    <key>compileBitcode</key>
+    <false/>
+</dict>
+</plist>
+EOF
+
+# Export the archive to IPA (allow this to fail without exiting)
+set +e  # Temporarily disable exit on error
+xcodebuild \
+  -exportArchive \
+  -archivePath "ios/build/${SCHEME_NAME}.xcarchive" \
+  -exportPath "ios/build" \
+  -exportOptionsPlist ios/build/ExportOptions.plist \
+  -allowProvisioningUpdates 2>&1 | grep -v "exportArchive" || true
+set -e  # Re-enable exit on error
+
+# Find the generated IPA
+IPA_PATH=$(find ios/build -name "*.ipa" 2>/dev/null | head -n 1)
+
+if [ -z "$IPA_PATH" ]; then
+  # If IPA not found, try to create it manually from .app
+  echo -e "${YELLOW}⚠️  IPA not exported, creating manually from .app bundle...${NC}"
+  
+  APP_PATH="ios/build/${SCHEME_NAME}.xcarchive/Products/Applications/${SCHEME_NAME}.app"
+  if [ ! -d "$APP_PATH" ]; then
+    APP_PATH=$(find "ios/build/${SCHEME_NAME}.xcarchive/Products/Applications" -name "*.app" | head -n 1)
+  fi
+  
+  if [ -d "$APP_PATH" ]; then
+    # Create Payload directory and copy .app
+    PAYLOAD_DIR="ios/build/Payload"
+    mkdir -p "$PAYLOAD_DIR"
+    cp -r "$APP_PATH" "$PAYLOAD_DIR/"
+    
+    # Create IPA by zipping Payload directory
+    cd ios/build
+    zip -r "SmartPocket-${VARIANT}.ipa" Payload
+    cd ../..
+    
+    IPA_PATH="ios/build/SmartPocket-${VARIANT}.ipa"
+  else
+    echo -e "${RED}❌ Could not find .app bundle${NC}"
+    exit 1
+  fi
+fi
+
+# Copy IPA to builds directory with proper naming
+OUTPUT_NAME="mobile-${VARIANT}.ipa"
+cp "$IPA_PATH" "builds/$OUTPUT_NAME"
+
+echo -e "${GREEN}✅ IPA exported successfully${NC}"
+echo ""
+
+# Step 6: Summary
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo -e "${GREEN}🎉 iOS Build Complete!${NC}"
+echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+echo ""
+echo -e "${BLUE}📦 IPA Location:${NC}"
+echo -e "   ${MOBILE_DIR}/builds/${OUTPUT_NAME}"
+echo ""
+echo -e "${BLUE}📱 File Size:${NC}"
+du -h "builds/$OUTPUT_NAME" | awk '{print "   " $1}'
+echo ""
+echo -e "${YELLOW}⚠️  This is an UNSIGNED IPA${NC}"
+echo ""
+echo -e "${BLUE}🔧 To install on your device:${NC}"
+echo -e "   1. Install AltStore on your iOS device"
+echo -e "   2. Transfer this IPA to your device"
+echo -e "   3. Open with AltStore to sign with your Apple ID"
+echo -e "   4. Re-sign every 7 days (free Apple ID limitation)"
+echo ""
+echo -e "${BLUE}💡 Alternative: Use Xcode${NC}"
+echo -e "   1. Open ${WORKSPACE}"
+echo -e "   2. Connect your iPhone"
+echo -e "   3. Select your device in Xcode"
+echo -e "   4. Click Run (⌘R) - Xcode will sign automatically"
+echo ""

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smart-pocket/server",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "Smart Pocket Server - Node.js backend",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "smart-pocket",
-  "version": "0.2.0",
-  "buildNumber": 7,
+  "version": "0.2.1",
+  "buildNumber": 8,
   "private": true,
   "description": "Smart Pocket - Personal finance management with OCR receipt scanning",
   "workspaces": [


### PR DESCRIPTION
Closes #92

## Release Version 0.2.1

### Changes
- ✅ Replace EAS iOS build with local build script (build-ios-local.sh)
- ✅ Add AltStore Source Manager upload integration
- ✅ Update GitHub secrets documentation
- ✅ Bump version to 0.2.1 and buildNumber to 8

### Testing This Release
This is a test release to validate:
1. iOS local build script in GitHub Actions
2. AltStore Source Manager upload workflow
3. Production deployment pipeline

### Distribution
- **Android**: Firebase App Distribution (production-testers group)
- **iOS**: AltStore Source Manager + GitHub Actions artifact

### Testing Notes
- Validates iOS build without EAS CLI
- Tests unsigned IPA generation for AltStore sideloading
- Verifies AltStore Source Manager API integration